### PR TITLE
refine cli options using Clikt

### DIFF
--- a/wsdl2kotlin/build.gradle
+++ b/wsdl2kotlin/build.gradle
@@ -36,6 +36,7 @@ dependencies {
     implementation 'com.google.guava:guava:30.1.1-jre'
 
     implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.12.2"
+    implementation "com.github.ajalt.clikt:clikt:3.1.0"
 
     // Use the Kotlin test library.
     testImplementation 'org.jetbrains.kotlin:kotlin-test'

--- a/wsdl2kotlin/src/main/kotlin/org/codefirst/wsdl2kotlin/Main.kt
+++ b/wsdl2kotlin/src/main/kotlin/org/codefirst/wsdl2kotlin/Main.kt
@@ -1,9 +1,27 @@
 package org.codefirst.wsdl2kotlin
 
-fun main(args: Array<String>) {
-    val outputs = WSDL2Kotlin().run(*args)
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.parameters.arguments.argument
+import com.github.ajalt.clikt.parameters.arguments.multiple
+import com.github.ajalt.clikt.parameters.arguments.unique
+import com.github.ajalt.clikt.parameters.options.default
+import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.parameters.types.path
+import java.nio.file.Path
 
-    outputs.forEach {
-        it.save()
+class Main : CliktCommand() {
+    val dir: String by option("-d", "--dir", help = "output directory").default("./")
+    val paths: Set<Path> by argument().path(mustExist = true).multiple().unique()
+
+    override fun run() {
+        val outputs = WSDL2Kotlin().run(*paths.map { it.toString() }.toTypedArray())
+
+        outputs.forEach {
+            it.save(dir)
+        }
     }
+}
+
+fun main(args: Array<String>) {
+    Main().main(args)
 }


### PR DESCRIPTION
help (`--help`)

```
Usage: main [OPTIONS] [PATHS]...

Options:
  -d, --dir TEXT  output directory
  -h, --help      Show this message and exit
```

For example,

```
-d output /path/to/sample.wsdl /path/to/sample.xsd
```