### PR TITLE
Add a work around to avoid invalid escape with surrogate pairs

### DIFF
--- a/wsdl2kotlin-runtime/src/main/kotlin/org/codefirst/wsdl2kotlin/FixSurrogatePairOutputStream.kt
+++ b/wsdl2kotlin-runtime/src/main/kotlin/org/codefirst/wsdl2kotlin/FixSurrogatePairOutputStream.kt
@@ -1,0 +1,71 @@
+package org.codefirst.wsdl2kotlin
+
+import java.io.ByteArrayOutputStream
+import java.io.OutputStream
+
+// to fix https://bugs.openjdk.java.net/browse/JDK-8203810
+class FixSurrogatePairOutputStream(private val outputStream: OutputStream) : OutputStream() {
+
+    private val buffer = ByteArrayOutputStream()
+
+    private var inNumericalCharacterReferences = false
+
+    private var highChar: Int = 0
+
+    override fun write(b: Int) {
+        if ('&'.code == b) {
+            inNumericalCharacterReferences = true
+        }
+
+        if (inNumericalCharacterReferences) {
+            buffer.write(b)
+
+            if (';'.code == b) {
+                inNumericalCharacterReferences = false
+
+                // &#55360;
+                val numericalCharacterReferences = buffer.toString()
+
+                // 55360
+                val charCode = numericalCharacterReferences
+                    .removePrefix("&#")
+                    .removeSuffix(";")
+                    .toIntOrNull()
+
+                if (charCode == null) {
+                    highChar = 0
+                    outputStream.write(numericalCharacterReferences.toByteArray())
+                } else {
+                    if ('\uD800'.code <= charCode && charCode <= '\uDBFF'.code) {
+                        highChar = charCode
+                    } else {
+                        if (highChar > 0) {
+                            // 𠀋
+                            val unicode = String(intArrayOf(highChar, charCode), 0, 2)
+
+                            // 131083
+                            val codePoint = unicode.codePointAt(0)
+
+                            // &#131083;
+                            outputStream.write("&#$codePoint;".toByteArray())
+
+                            highChar = 0
+                        } else {
+                            // &#60;
+                            outputStream.write("&#$charCode;".toByteArray())
+                        }
+                    }
+                }
+
+                buffer.reset()
+            }
+        } else {
+            outputStream.write(b)
+        }
+    }
+
+    override fun close() {
+        outputStream.write(buffer.toByteArray())
+        outputStream.close()
+    }
+}

--- a/wsdl2kotlin-runtime/src/main/kotlin/org/codefirst/wsdl2kotlin/WSDLService.kt
+++ b/wsdl2kotlin-runtime/src/main/kotlin/org/codefirst/wsdl2kotlin/WSDLService.kt
@@ -209,7 +209,10 @@ abstract class WSDLService() {
             override fun contentType() = "text/xml".toMediaTypeOrNull()
 
             override fun writeTo(sink: BufferedSink) {
-                DocumentHelper.newTransformer().transform(DOMSource(soapRequest), StreamResult(sink.outputStream()))
+                DocumentHelper.newTransformer().transform(
+                    DOMSource(soapRequest),
+                    StreamResult(FixSurrogatePairOutputStream(sink.outputStream()))
+                )
             }
         }
 

--- a/wsdl2kotlin-runtime/src/test/kotlin/org/codefirst/wsdl2kotlin/FixSurrogatePairOutputStreamTest.kt
+++ b/wsdl2kotlin-runtime/src/test/kotlin/org/codefirst/wsdl2kotlin/FixSurrogatePairOutputStreamTest.kt
@@ -1,0 +1,47 @@
+package org.codefirst.wsdl2kotlin
+
+import org.junit.Test
+import java.io.ByteArrayOutputStream
+import kotlin.test.assertEquals
+
+class FixSurrogatePairOutputStreamTest {
+
+    private fun assertStream(input: String, output: String) {
+        val byteStream = ByteArrayOutputStream()
+        val stream = FixSurrogatePairOutputStream(byteStream)
+        stream.bufferedWriter().use {
+            it.write(input)
+        }
+        assertEquals(output, byteStream.toString())
+    }
+
+    @Test
+    fun testSimpleString() {
+        assertStream("Hello World", "Hello World")
+    }
+
+    @Test
+    fun testSurrogatePairString() {
+        assertStream("&#55360;&#56331;", "&#131083;")
+    }
+
+    @Test
+    fun testSuspiciousString1() {
+        assertStream("&amp;", "&amp;")
+    }
+
+    @Test
+    fun testSuspiciousString2() {
+        assertStream("&#38;", "&#38;")
+    }
+
+    @Test
+    fun testSuspiciousString3() {
+        assertStream(";", ";")
+    }
+
+    @Test
+    fun testSuspiciousString4() {
+        assertStream("&", "&")
+    }
+}


### PR DESCRIPTION
If you use WSDL2Kotlin on Android, WSDL2Kotlin generates invalid XML.
This problem is caused by https://issues.apache.org/jira/browse/XALANJ-2617

This PR adds a work around.