### PR TITLE
Fix request url has duplicated slashes

### DIFF
--- a/wsdl2kotlin-runtime/src/main/kotlin/org/codefirst/wsdl2kotlin/WSDLService.kt
+++ b/wsdl2kotlin-runtime/src/main/kotlin/org/codefirst/wsdl2kotlin/WSDLService.kt
@@ -210,6 +210,9 @@ abstract class WSDLService() {
 
     protected val interceptors = mutableListOf<Interceptor>()
 
+    protected val requestUrl: String
+        get() = endpoint.removeSuffix("/") + "/" + path.removePrefix("/")
+
     protected inline fun <I : XSDType, reified O : XSDType> requestGeneric(i: I): O {
         val soapRequest = i.soapRequest(targetNamespace)
 
@@ -225,7 +228,7 @@ abstract class WSDLService() {
         }
 
         val request = Request.Builder()
-            .url("$endpoint/$path")
+            .url(requestUrl)
             .post(requestBody)
             .build()
         val client = OkHttpClient.Builder()


### PR DESCRIPTION
If I wrote code like below:
```kt
SampleService().apply {
    this.endpoint = "http://localhost:8080/"
    this.path = "/service"
}
```

`wsdl2kotlin-runtime` access to `http://localhost:8080///service`.
I guess that the access url should be `http://localhost:8080/service` .

This PR will fix this problem.