### PR TITLE
Remove Gradle Maven Plugin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Build wsdl2kotlin
         run: |
           cd wsdl2kotlin
-          ../gradlew test build install
+          ../gradlew test build publishToMavenLocal
       - name: Build wsdl2kotlin-runtime
         run: |
           cd wsdl2kotlin-runtime

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Build wsdl2kotlin
         run: |
           cd wsdl2kotlin
-          ../gradlew test build install publish
+          ../gradlew test build publishToMavenLocal publish
       - name: Build wsdl2kotlin-runtime
         run: |
           cd wsdl2kotlin-runtime

--- a/wsdl2kotlin/build.gradle
+++ b/wsdl2kotlin/build.gradle
@@ -15,7 +15,6 @@ plugins {
 
     id "org.jetbrains.kotlin.kapt" version "1.7.21"
 
-    id 'maven'
     id 'maven-publish'
 }
 


### PR DESCRIPTION
Gradle Maven Plugin is deprecated on Gradle 7.0.
Move to Gradle Maven Publish Plugin.

https://qiita.com/kagamihoge/items/1c9639820d568e06504d