### PR TITLE
Grouped version updates for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,10 @@ updates:
       interval: "weekly"
       timezone: "Asia/Tokyo"
       day: "friday"
+    groups:
+      org.jetbrains.kotlin:
+        patterns:
+          - "org.jetbrains.kotlin.*"
 
   - package-ecosystem: "gradle"
     directory: "/wsdl2kotlin-runtime/"


### PR DESCRIPTION
[Grouped version updates for Dependabot public beta | GitHub Changelog](https://github.blog/changelog/2023-06-30-grouped-version-updates-for-dependabot-public-beta/)