### PR TITLE
Revert "build(deps): bump com.fasterxml.jackson.dataformat:jackson-dataformat-xml from 2.16.0 to 2.16.1 in /wsdl2kotlin"

### DIFF
--- a/wsdl2kotlin/build.gradle
+++ b/wsdl2kotlin/build.gradle
@@ -36,7 +36,7 @@ dependencies {
     // This dependency is used internally, and not exposed to consumers on their own compile classpath.
     implementation 'com.google.guava:guava:32.1.3-jre'
 
-    implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.16.1"
+    implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.16.0"
     implementation "com.github.ajalt.clikt:clikt:4.2.1"
 
     // Use the Kotlin test library.


### PR DESCRIPTION
Reverts suer/wsdl2kotlin#342

## What's happened?

My Android project (Gradle 8.2) fails to build:

```
> java.util.concurrent.ExecutionException: org.gradle.api.GradleException: Failed to create Jar file /home/runner/.gradle/caches/jars-9/6b475b24173502a904998db53a2faa11/jackson-core-2.16.1.jar.
```

jackson-core is a multi-release JAR.
Gradle 8.2- cannot deal with multi-release JARs that contain too new Java (It fixed on 8.3).
jackson-core changed Java version in 2.16.0 to 2.16.1.

jackson-core-2.16.0 contains 11/17/19:
```
$ unzip -t jackson-core-2.16.0.jar | grep FastDoubleSwar.class
    testing: com/fasterxml/jackson/core/io/doubleparser/FastDoubleSwar.class   OK
    testing: META-INF/versions/11/com/fasterxml/jackson/core/io/doubleparser/FastDoubleSwar.class   OK
    testing: META-INF/versions/17/com/fasterxml/jackson/core/io/doubleparser/FastDoubleSwar.class   OK
    testing: META-INF/versions/19/com/fasterxml/jackson/core/io/doubleparser/FastDoubleSwar.class   OK
```

jackson-core-2.16.1 contains 11/17/21:
```
$ unzip -t jackson-core-2.16.1.jar | grep FastDoubleSwar.class
    testing: com/fasterxml/jackson/core/io/doubleparser/FastDoubleSwar.class   OK
    testing: META-INF/versions/11/com/fasterxml/jackson/core/io/doubleparser/FastDoubleSwar.class   OK
    testing: META-INF/versions/17/com/fasterxml/jackson/core/io/doubleparser/FastDoubleSwar.class   OK
    testing: META-INF/versions/21/com/fasterxml/jackson/core/io/doubleparser/FastDoubleSwar.class   OK
```

I do not want to change supporting Gradle version.
So I revert #342 .