### PR TITLE
main to mainClass

### DIFF
--- a/wsdl2kotlin-runtime/build.gradle
+++ b/wsdl2kotlin-runtime/build.gradle
@@ -86,7 +86,7 @@ publishing {
 task ktlint(type: JavaExec, group: "verification") {
     description = "Check Kotlin code style."
     classpath = configurations.ktlint
-    main = "com.pinterest.ktlint.Main"
+    mainClass = "com.pinterest.ktlint.Main"
     args "src/**/*.kt"
 }
 check.dependsOn ktlint
@@ -94,6 +94,6 @@ check.dependsOn ktlint
 task ktlintFormat(type: JavaExec, group: "formatting") {
     description = "Fix Kotlin code style deviations."
     classpath = configurations.ktlint
-    main = "com.pinterest.ktlint.Main"
+    mainClass = "com.pinterest.ktlint.Main"
     args "-F", "src/**/*.kt"
 }

--- a/wsdl2kotlin/build.gradle
+++ b/wsdl2kotlin/build.gradle
@@ -85,7 +85,7 @@ publishing {
 task ktlint(type: JavaExec, group: "verification") {
     description = "Check Kotlin code style."
     classpath = configurations.ktlint
-    main = "com.pinterest.ktlint.Main"
+    mainClass = "com.pinterest.ktlint.Main"
     args "src/**/*.kt"
 }
 check.dependsOn ktlint
@@ -93,6 +93,6 @@ check.dependsOn ktlint
 task ktlintFormat(type: JavaExec, group: "formatting") {
     description = "Fix Kotlin code style deviations."
     classpath = configurations.ktlint
-    main = "com.pinterest.ktlint.Main"
+    mainClass = "com.pinterest.ktlint.Main"
     args "-F", "src/**/*.kt"
 }


### PR DESCRIPTION
Remove below warnings.

```
The JavaExecSpec.main property has been deprecated. This is scheduled to be removed in Gradle 9.0. Please use the mainClass property instead. For more information, please refer to https://docs.gradle.org/8.3/dsl/org.gradle.process.JavaExecSpec.html#org.gradle.process.JavaExecSpec:main in the Gradle documentation.
```