### PR TITLE
Remove kapt

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,10 +6,6 @@ updates:
       interval: "weekly"
       timezone: "Asia/Tokyo"
       day: "friday"
-    groups:
-      org.jetbrains.kotlin:
-        patterns:
-          - "org.jetbrains.kotlin.*"
 
   - package-ecosystem: "gradle"
     directory: "/wsdl2kotlin-runtime/"

--- a/wsdl2kotlin/build.gradle
+++ b/wsdl2kotlin/build.gradle
@@ -13,8 +13,6 @@ plugins {
     // Apply the java-library plugin for API and implementation separation.
     id 'java-library'
 
-    id "org.jetbrains.kotlin.kapt" version "2.0.10"
-
     id 'maven-publish'
 }
 


### PR DESCRIPTION
TikXML parser ( #1 ) needed kapt.
But TikXML parser is no longer in use.