### PR TITLE
Specify version of kotlin-bom

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,11 @@ updates:
       interval: "weekly"
       timezone: "Asia/Tokyo"
       day: "friday"
+    groups:
+      kotlin:
+        patterns:
+          - "org.jetbrains.kotlin.jvm"
+          - "org.jetbrains.kotlin:kotlin-bom"
 
   - package-ecosystem: "gradle"
     directory: "/wsdl2kotlin-runtime/"
@@ -13,6 +18,11 @@ updates:
       interval: "weekly"
       timezone: "Asia/Tokyo"
       day: "friday"
+    groups:
+      kotlin:
+        patterns:
+          - "org.jetbrains.kotlin.jvm"
+          - "org.jetbrains.kotlin:kotlin-bom"
 
   - package-ecosystem: "gradle"
     directory: "/wsdl2kotlin-gradle-plugin/"
@@ -20,6 +30,11 @@ updates:
       interval: "weekly"
       timezone: "Asia/Tokyo"
       day: "friday"
+    groups:
+      kotlin:
+        patterns:
+          - "org.jetbrains.kotlin.jvm"
+          - "org.jetbrains.kotlin:kotlin-stdlib"
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/wsdl2kotlin-gradle-plugin/build.gradle
+++ b/wsdl2kotlin-gradle-plugin/build.gradle
@@ -12,7 +12,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.jetbrains.kotlin:kotlin-stdlib'
+    implementation 'org.jetbrains.kotlin:kotlin-stdlib:2.0.10'
     implementation gradleApi()
     implementation 'org.codefirst.wsdl2kotlin:wsdl2kotlin:0.7.0-SNAPSHOT'
 }

--- a/wsdl2kotlin-runtime/build.gradle
+++ b/wsdl2kotlin-runtime/build.gradle
@@ -26,7 +26,7 @@ configurations {
 
 dependencies {
     // Align versions of all Kotlin components
-    implementation platform('org.jetbrains.kotlin:kotlin-bom')
+    implementation platform('org.jetbrains.kotlin:kotlin-bom:2.0.10')
 
     // Use the Kotlin standard library.
     implementation 'org.jetbrains.kotlin:kotlin-stdlib'

--- a/wsdl2kotlin/build.gradle
+++ b/wsdl2kotlin/build.gradle
@@ -26,7 +26,7 @@ configurations {
 
 dependencies {
     // Align versions of all Kotlin components
-    implementation platform('org.jetbrains.kotlin:kotlin-bom')
+    implementation platform('org.jetbrains.kotlin:kotlin-bom:2.0.10')
 
     // Use the Kotlin standard library.
     implementation 'org.jetbrains.kotlin:kotlin-stdlib'


### PR DESCRIPTION
When I use Kotlin 2.0.20, I catch below error:

```
* What went wrong:
Execution failed for task ':wsdl2kotlin-gradle-plugin:compileKotlin'.
> Could not resolve all files for configuration ':wsdl2kotlin-gradle-plugin:compileClasspath'.
   > Could not resolve org.codefirst.wsdl2kotlin:wsdl2kotlin:0.7.0-SNAPSHOT.
     Required by:
         project :wsdl2kotlin-gradle-plugin
      > Could not resolve org.codefirst.wsdl2kotlin:wsdl2kotlin:0.7.0-SNAPSHOT.
         > Could not parse POM /home/runner/.m2/repository/org/codefirst/wsdl2kotlin/wsdl2kotlin/0.7.0-SNAPSHOT/wsdl2kotlin-0.7.0-SNAPSHOT.pom
            > Required version must not be null
```

I can prevent this error if I specified kotlin-bom version.
So I add the version to kotlin-bom explicitly.