### PR TITLE
Skip unsupported XXE-hardening features gracefully on Android

### DIFF
--- a/wsdl2kotlin-runtime/src/main/kotlin/org/codefirst/wsdl2kotlin/DocumentHelper.kt
+++ b/wsdl2kotlin-runtime/src/main/kotlin/org/codefirst/wsdl2kotlin/DocumentHelper.kt
@@ -4,8 +4,10 @@ import org.w3c.dom.Element
 import javax.xml.XMLConstants
 import javax.xml.parsers.DocumentBuilder
 import javax.xml.parsers.DocumentBuilderFactory
+import javax.xml.parsers.ParserConfigurationException
 import javax.xml.transform.OutputKeys
 import javax.xml.transform.Transformer
+import javax.xml.transform.TransformerConfigurationException
 import javax.xml.transform.TransformerFactory
 
 object DocumentHelper {
@@ -14,23 +16,23 @@ object DocumentHelper {
             .newInstance()
             .apply {
                 isNamespaceAware = true
-                isXIncludeAware = false
                 isExpandEntityReferences = false
-                setFeature("http://apache.org/xml/features/disallow-doctype-decl", true)
-                setFeature("http://xml.org/sax/features/external-general-entities", false)
-                setFeature("http://xml.org/sax/features/external-parameter-entities", false)
-                setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false)
-                setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true)
+                trySetXIncludeAware(false)
+                trySetFeature("http://apache.org/xml/features/disallow-doctype-decl", true)
+                trySetFeature("http://xml.org/sax/features/external-general-entities", false)
+                trySetFeature("http://xml.org/sax/features/external-parameter-entities", false)
+                trySetFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false)
+                trySetFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true)
             }.newDocumentBuilder()
 
     fun newTransformer(): Transformer =
         TransformerFactory
             .newInstance()
             .apply {
-                setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true)
+                trySetFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true)
             }.newTransformer()
             .apply {
-                this.setOutputProperty(OutputKeys.INDENT, "yes")
+                setOutputProperty(OutputKeys.INDENT, "yes")
             }
 
     fun getChildElementsByTagName(
@@ -46,5 +48,37 @@ object DocumentHelper {
             }
         }
         return nodes
+    }
+
+    // Android's JAXP implementation (not Xerces) doesn't recognize Xerces-specific
+    // features like disallow-doctype-decl or support isXIncludeAware, and throws
+    // UnsupportedOperationException. Ignore on unsupported platforms instead of crashing.
+    private fun DocumentBuilderFactory.trySetXIncludeAware(value: Boolean) {
+        try {
+            isXIncludeAware = value
+        } catch (e: UnsupportedOperationException) {
+        }
+    }
+
+    private fun DocumentBuilderFactory.trySetFeature(
+        name: String,
+        value: Boolean,
+    ) {
+        try {
+            setFeature(name, value)
+        } catch (e: ParserConfigurationException) {
+        } catch (e: UnsupportedOperationException) {
+        }
+    }
+
+    private fun TransformerFactory.trySetFeature(
+        name: String,
+        value: Boolean,
+    ) {
+        try {
+            setFeature(name, value)
+        } catch (e: TransformerConfigurationException) {
+        } catch (e: UnsupportedOperationException) {
+        }
     }
 }


### PR DESCRIPTION
## Summary
- `DocumentHelper.newDocumentBuilder()`/`newTransformer()` set several Xerces-specific `DocumentBuilderFactory`/`TransformerFactory` features to prevent XXE attacks when parsing untrusted SOAP responses.
- Android's built-in JAXP implementation is not Xerces and throws `UnsupportedOperationException` for `isXIncludeAware` and most of the `setFeature(...)` calls, crashing at runtime.
- Wrap each optional feature setter (`trySetXIncludeAware`, `trySetFeature`) in a try/catch that ignores `ParserConfigurationException`/`TransformerConfigurationException`/`UnsupportedOperationException`, so unsupported platforms silently skip the setting instead of crashing, while desktop/server JVMs keep full protection.

## Test plan
- [x] `./gradlew :wsdl2kotlin-runtime:test`
- [x] `./gradlew :wsdl2kotlin-runtime:check` (ktlint)
- [x] `./gradlew build` (all modules)
- [ ] Manual verification on an Android device/emulator that `UnsupportedOperationException` no longer occurs

🤖 Generated with [Claude Code](https://claude.com/claude-code)